### PR TITLE
drush dl is deprecated for Drush 9

### DIFF
--- a/scripts/install_drupal8.sh
+++ b/scripts/install_drupal8.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 
-docker-compose exec --user=1000:1000 web composer global require drush/drush
+docker-compose exec --user=1000:1000 web composer global require drush/drush:8.x-dev
 docker-compose exec web ln -s /home/www-bridge-user/.composer/vendor/bin/drush /usr/bin/drush
 docker-compose exec --user=1000:1000 web sh -c 'drush dl -y --destination=/var/www/html --drupal-project-rename=drupal8 drupal && cd /var/www/html/drupal8 && drush si --db-url=mysql://root:123@db/drupal8 -y'


### PR DESCRIPTION
There are two ways I see this issue could be fixed,

1) Upgrading command structure in L5 of install_drupal8.sh to follow up with composer config

2) Forcing drush 8 installation in L3 of install_drupal8.sh

This PR is solving the issue via 2 approach

Forces drush 8 installation and therefore fixing the Drush 9 depecrated
error.

Reference: https://drushcommands.com/drush-9x/pm/pm:download/